### PR TITLE
bump devalue

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@vitest/coverage-v8": "3.2.4",
     "@vitest/ui": "^3.2.4",
     "bunchee": "^6.6.0",
-    "devalue": "^5.1.1",
+    "devalue": "^5.3.2",
     "happy-dom": "^18.0.1",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"
@@ -52,7 +52,7 @@
   "packageManager": "pnpm@8.7.0+sha512.1d61f8c10e8a5a5dbfbddea0f1f5efb7dbd5177223073aec953cf230aa46416884b9427a6421dba78f28ad0f93fbede38ba57083237b350243de6b1e3a8ce71d",
   "pnpm": {
     "patchedDependencies": {
-      "devalue@5.1.1": "patches/devalue@5.1.1.patch"
+      "devalue@5.3.2": "patches/devalue@5.3.2.patch"
     }
   }
 }

--- a/patches/devalue@5.3.2.patch
+++ b/patches/devalue@5.3.2.patch
@@ -1,15 +1,15 @@
 diff --git a/src/stringify.js b/src/stringify.js
-index df291fdf1a10d076dae1cb2dcdb717b2c9fd042f..0c2d8f39830b80d0b236e29635b4f0e906867f09 100644
+index bec2e587a7a2fd20bae08aecc7df0231d31a51d6..8548cce5b7dee97f3d198c6cb400979a8cd4e977 100644
 --- a/src/stringify.js
 +++ b/src/stringify.js
 @@ -44,10 +44,6 @@ export function stringify(value, reducers) {
- 
+
  	/** @param {any} thing */
  	function flatten(thing) {
 -		if (typeof thing === 'function') {
 -			throw new DevalueError(`Cannot stringify a function`, keys);
 -		}
 -
- 		if (indexes.has(thing)) return indexes.get(thing);
- 
  		if (thing === undefined) return UNDEFINED;
+ 		if (Number.isNaN(thing)) return NAN;
+ 		if (thing === Infinity) return POSITIVE_INFINITY;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  devalue@5.1.1:
-    hash: nvl2t35lrhsgbxgtspzw4w55h4
-    path: patches/devalue@5.1.1.patch
+  devalue@5.3.2:
+    hash: srqex2kkl42z7ua5mi2nqfq2lu
+    path: patches/devalue@5.3.2.patch
 
 devDependencies:
   '@vitest/coverage-v8':
@@ -20,8 +20,8 @@ devDependencies:
     specifier: ^6.6.0
     version: 6.6.0(typescript@5.9.2)
   devalue:
-    specifier: ^5.1.1
-    version: 5.1.1(patch_hash=nvl2t35lrhsgbxgtspzw4w55h4)
+    specifier: ^5.3.2
+    version: 5.3.2(patch_hash=srqex2kkl42z7ua5mi2nqfq2lu)
   happy-dom:
     specifier: ^18.0.1
     version: 18.0.1
@@ -1098,8 +1098,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /devalue@5.1.1(patch_hash=nvl2t35lrhsgbxgtspzw4w55h4):
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+  /devalue@5.3.2(patch_hash=srqex2kkl42z7ua5mi2nqfq2lu):
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
     dev: true
     patched: true
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -117,7 +117,7 @@ describe('encode/decode', () => {
 
     expect(chunks).toMatchInlineSnapshot(`
       [
-        "r:[{"array":1,"date":9,"map":10,"set":15,"regex":17,"bigint":18,"buffer":19,"uint8":20},[2,3,4,6],1,"two",{"three":5},3,[7,8],4,5,["Date","2024-01-01T00:00:00.000Z"],["Map",11,12,13,14],"key","value","num",42,["Set",2,16,5],2,["RegExp","test.*pattern","gi"],["BigInt","12345678901234567890"],["ArrayBuffer","AAAAAAAAAAA="],["Uint8Array","AQIDBA=="]]
+        "r:[{"array":1,"date":9,"map":10,"set":15,"regex":17,"bigint":18,"buffer":19,"uint8":20},[2,3,4,6],1,"two",{"three":5},3,[7,8],4,5,["Date","2024-01-01T00:00:00.000Z"],["Map",11,12,13,14],"key","value","num",42,["Set",2,16,5],2,["RegExp","test.*pattern","gi"],["BigInt","12345678901234567890"],["ArrayBuffer","AAAAAAAAAAA="],["Uint8Array",21],["ArrayBuffer","AQIDBA=="]]
       ",
       ]
     `)


### PR DESCRIPTION
This addresses [CVE-2025-57820](https://github.com/sveltejs/devalue/security/advisories/GHSA-vj54-72f3-p5jv)